### PR TITLE
Category's Styling Change 

### DIFF
--- a/src/lib/Molecules/ArticleAlt.svelte
+++ b/src/lib/Molecules/ArticleAlt.svelte
@@ -1,0 +1,120 @@
+<script>
+    export let post;
+
+    const dateFormat = {
+        month: 'short',
+        day: 'numeric',
+    };
+</script>
+
+<a href="/{post.slug}" class="post-title-link">
+    <article class="post-card">
+        <h3 class="post-title">{@html post.title.rendered}</h3>
+        <img 
+            src={post.yoast_head_json.og_image[0].url} 
+            alt="Artikel afbeelding" 
+            class="post-image" 
+            width="350" 
+            height="350" 
+        />
+        <div class="post-meta">
+            <p class="post-date">
+                {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
+            </p>
+            <p class="post-read-time">
+                {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
+            </p>
+            <p class="post-author">{post.yoast_head_json.author}</p>
+        </div>
+    </article>
+</a>
+
+<style>
+    .post-title-link {
+        text-decoration: none;
+        color: inherit;
+        display: block;
+        width: 100%;
+    }
+
+    .post-title-link:hover {
+        text-decoration: underline;
+    }
+
+    .post-card {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        width: 100%;
+        max-width: 800px;
+        margin: 0 auto;
+        padding: 1rem;
+        cursor: pointer;
+        background: #fff;
+        border: 1px solid #ddd;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+        box-sizing: border-box;
+        position: relative;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .post-card:hover {
+        transform: translateY(-5px); 
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); 
+    }
+
+    .post-image {
+        object-fit: cover;
+        width: 200px;
+        height: auto;
+        border: 1px solid black;
+        flex-shrink: 0;
+    }
+
+    .post-title {
+        font-size: 1.2rem;
+        margin: 0;
+        flex-grow: 1;
+        padding-right: 1rem;
+    }
+
+    .post-meta {
+        font-size: 0.8rem;
+        position: absolute;
+        bottom: 0.5rem;
+        left: 1rem;
+        display: flex;
+        gap: 0.2rem;
+    }
+
+    .post-author {
+        font-weight: var(--font-style-bold);
+    }
+
+    @media (max-width: 768px) {
+        .post-card {
+            max-width: 600px;
+            width: 100%;
+        }
+
+        .post-image {
+            width: 120px;
+            height: 120px;
+        }
+    }
+
+    @media (max-width: 480px) {
+        .post-title {
+            font-size: 1rem;
+        }
+
+        .post-meta {
+            font-size: 0.7rem;
+        }
+
+        .post-image {
+            width: 100px;
+            height: 100px;
+        }
+    }
+</style>

--- a/src/lib/Molecules/ArticleAlt.svelte
+++ b/src/lib/Molecules/ArticleAlt.svelte
@@ -46,6 +46,7 @@
         justify-content: space-between;
         align-items: flex-start;
         width: 100%;
+        height: 10em;
         max-width: 800px;
         margin: 0 auto;
         padding: 1rem;
@@ -66,7 +67,7 @@
     .post-image {
         object-fit: cover;
         width: 200px;
-        height: auto;
+        height: 100%;
         border: 1px solid black;
         flex-shrink: 0;
     }

--- a/src/lib/Organism/CategoryPreview.svelte
+++ b/src/lib/Organism/CategoryPreview.svelte
@@ -6,6 +6,9 @@
     export let posts;
 </script>
 
+
+
+
 <div>
     <div class="category-name">
         <h1>{categoryName}</h1>
@@ -47,7 +50,7 @@
 
     .articles {
         justify-self: start;
-
+        border: 2px solid black;
         display: flex;
         flex-wrap: wrap;
         gap: 1em;

--- a/src/lib/Organism/Header.svelte
+++ b/src/lib/Organism/Header.svelte
@@ -104,6 +104,7 @@
         position: fixed;
         top: -1px; /* Hide upper inner border */
         left: 0;
+        z-index: 100;
         border-bottom: var(--border);
     }
 

--- a/src/lib/Organism/Nav.svelte
+++ b/src/lib/Organism/Nav.svelte
@@ -46,6 +46,7 @@
     .sticky nav {
         position: fixed;
         top: 5em;
+        z-index: 100;
         left: 0;
         background-color: var(--background-color);
     }

--- a/src/routes/categorie/[slug]/+page.js
+++ b/src/routes/categorie/[slug]/+page.js
@@ -1,6 +1,7 @@
 import wp from "$lib/wordpress";
 import { error } from "@sveltejs/kit";
 import { categoriesData } from "$lib/index.js";
+console.log (categoriesData);
 
 export async function load({ params }) {
     const category = categoriesData.find((category) => category.slug === params.slug)
@@ -13,3 +14,4 @@ export async function load({ params }) {
         posts: await wp.posts().param("categories", category.id)
     }
 }
+

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -1,8 +1,10 @@
 <script>
     import Footer from '$lib/Organism/Footer.svelte';
     import Header from '$lib/Organism/Header.svelte';
+    import Nav from '$lib/Organism/Nav.svelte';
     
     export let data;
+    export let categoryName;
 
     const dateFormat = {
         month: 'short',
@@ -10,25 +12,143 @@
     };
 </script>
 
-<Header/>
-
-<main>
+<Header alwaysSticky={false}/>
+<div class="background">
+<main class="posts-container">
+    <h1 class="page-title">Je bekijkt berichten in de categorie: {categoryName}</h1>
     {#if data.posts}
-    {#each data.posts as post}
-    <!-- @html means: there is html in this string, render it -->
-        <a href="/{post.slug}">
-            <h3>{@html post.title.rendered}</h3>
-        </a>
-        <p>{@html post.excerpt.rendered}</p>
-        <img src={post.yoast_head_json.og_image[0].url} alt="Artikel afbeelding" width="350" height="350">
-        <p>{(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}</p>
-        <p>{post.yoast_head_json.twitter_misc["Geschatte leestijd"]}</p>
-        <p>{post.yoast_head_json.author}</p>
-    {/each}
-{:else}
-    <!-- This will show if no posts are available -->
-    <p>No posts available</p>
-{/if}
+        {#each data.posts as post}
+            <article class="post-card">
+                <a href="/{post.slug}" class="post-title-link">
+                    <h3 class="post-title">{@html post.title.rendered}</h3>
+                </a>
+                <img 
+                    src={post.yoast_head_json.og_image[0].url} 
+                    alt="Artikel afbeelding" 
+                    class="post-image" 
+                    width="350" 
+                    height="350" 
+                />
+                <div class="post-meta">
+                <p class="post-date">
+                    {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
+                </p>
+                <p class="post-read-time">
+                    {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
+                </p>
+                <p class="post-author">{post.yoast_head_json.author}</p>
+            </div>
+            </article>
+        {/each}
+    {:else}
+        <p class="no-posts-message">No posts available</p>
+    {/if}
 </main>
+</div>
+
 
 <Footer />
+
+
+
+<style>
+
+/* Container voor posts */
+    .posts-container {
+        display: flex;
+        flex-direction: column; /* Artikelen onder elkaar */
+        gap: 1rem; /* Ruimte tussen de artikelen */
+        padding: 3em 1.5em; /* Ruimte aan de zijkanten */
+        align-items: center; /* Zorgt ervoor dat de posts in het midden staan */
+        justify-content: center; /* Geeft meer ruimte rondom */
+        box-sizing: border-box; /* Zorgt ervoor dat padding binnen de breedte valt */
+    }
+
+    .background{
+        background-color: var(--paper-color);
+    }
+
+    h1{
+        margin-top: -2rem;
+    }
+    
+    /* Individuele post-kaart */
+    .post-card {
+        display: flex;
+        justify-content: space-between; /* Zorgt ervoor dat de afbeelding altijd rechts komt */
+        align-items: flex-start; /* Zorgt ervoor dat de titel bovenaan staat */
+        width: 100%;
+        max-width: 800px; /* Max breedte van het artikel */
+        margin: 0 auto;
+        padding: 1rem; /* Kleinere padding */
+        background: #fff;
+        border: 1px solid #ddd;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        box-sizing: border-box; /* Zorgt ervoor dat padding binnen de breedte valt */
+        position: relative; /* Voor positionering van de info onderaan */
+    }
+    
+    /* Afbeelding in de post - rechtse afbeelding */
+    .post-image {
+        object-fit: cover;
+        width: 200px; /* Zorgt voor een breedte van de afbeelding */
+        height: auto;
+        border: 1px solid black;
+        flex-shrink: 0; /* Zorgt ervoor dat de afbeelding niet krimpt */
+    }
+    
+    /* Post-inhoud */
+    .post-title {
+        font-size: 1.2rem;
+        margin: 0; /* Geen marge boven of onder de titel */
+        flex-grow: 1; /* Zorgt ervoor dat de titel ruimte krijgt */
+        padding-right: 1rem; /* Ruimte tussen de titel en de afbeelding */
+    }
+    
+    /* Titel-link */
+    .post-title-link {
+        text-decoration: none;
+        color: inherit;
+    }
+    
+    .post-title-link:hover {
+        text-decoration: underline;
+    }
+    
+    /* Datum, leestijd, en auteur in de hoek onderaan */
+    .post-meta {
+        font-size: 0.8rem; /* Kleinere tekst voor de metadata */
+        position: absolute;
+        bottom: 0.5rem; /* Een beetje afstand van de onderkant */
+        left: 1rem; /* Plaatst het naar links in de hoek */
+        display: flex;
+        gap: 0.2rem;
+    }
+    
+    @media (max-width: 768px) {
+        .post-card {
+            max-width: 600px; /* Kleinere max breedte voor tablets en kleiner */
+        }
+    
+        .post-image {
+            width: 120px; /* Kleinere afbeelding voor tablets */
+            height: 120px; /* Zorgt dat de afbeelding proportioneel is */
+        }
+    }
+    
+    @media (max-width: 480px) {
+        .post-title {
+            font-size: 1rem; /* Kleinere titel op mobiele apparaten */
+        }
+    
+        .post-meta {
+            font-size: 0.7rem; /* Nog kleinere tekst voor mobiel */
+        }
+    
+        .post-image {
+            width: 100px; /* Kleinere afbeelding voor mobiele apparaten */
+            height: 100px; /* Zorgt dat de afbeelding proportioneel is */
+        }
+    }
+    
+</style>

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -2,13 +2,9 @@
     import Footer from '$lib/Organism/Footer.svelte';
     import Header from '$lib/Organism/Header.svelte';
     import Nav from '$lib/Organism/Nav.svelte';
+    import ArticleAlt from '$lib/Molecules/ArticleAlt.svelte';
 
     export let data;
-
-    const dateFormat = {
-        month: 'short',
-        day: 'numeric',
-    };
 </script>
 
 <Header alwaysSticky={true}/>
@@ -17,27 +13,7 @@
     <main class="posts-container">
         {#if data.posts}
             {#each data.posts as post}
-                <a href="/{post.slug}" class="post-title-link">
-                    <article class="post-card">
-                        <h3 class="post-title">{@html post.title.rendered}</h3>
-                        <img 
-                            src={post.yoast_head_json.og_image[0].url} 
-                            alt="Artikel afbeelding" 
-                            class="post-image" 
-                            width="350" 
-                            height="350" 
-                        />
-                        <div class="post-meta">
-                            <p class="post-date">
-                                {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
-                            </p>
-                            <p class="post-read-time">
-                                {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
-                            </p>
-                            <p class="post-author">{post.yoast_head_json.author}</p>
-                        </div>
-                    </article>
-                </a>
+                <ArticleAlt post={post} />
             {/each}
         {:else}
             <p class="no-posts-message">No posts available</p>
@@ -60,93 +36,5 @@
 
     .background {
         background-color: var(--paper-color);
-    }
-
-    .post-title-link {
-        text-decoration: none;
-        color: inherit;
-        display: block;
-        width: 100%;
-    }
-
-    .post-title-link:hover {
-        text-decoration: underline;
-    }
-
-    .post-card {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
-        width: 100%;
-        max-width: 800px;
-        margin: 0 auto;
-        padding: 1rem;
-        cursor: pointer;
-        background: #fff;
-        border: 1px solid #ddd;
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-        box-sizing: border-box;
-        position: relative;
-        transition: transform 0.3s ease, box-shadow 0.3s ease;
-    }
-
-    .post-card:hover {
-        transform: translateY(-5px); 
-        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); 
-    }
-
-    .post-image {
-        object-fit: cover;
-        width: 200px;
-        height: auto;
-        border: 1px solid black;
-        flex-shrink: 0;
-    }
-
-    .post-title {
-        font-size: 1.2rem;
-        margin: 0;
-        flex-grow: 1;
-        padding-right: 1rem;
-    }
-
-    .post-meta {
-        font-size: 0.8rem;
-        position: absolute;
-        bottom: 0.5rem;
-        left: 1rem;
-        display: flex;
-        gap: 0.2rem;
-    }
-
-    .post-author {
-        font-weight: var(--font-style-bold);
-    }
-
-    @media (max-width: 768px) {
-        .post-card {
-            max-width: 600px;
-            width: 100%;
-        }
-
-        .post-image {
-            width: 120px;
-            height: 120px;
-        }
-    }
-
-    @media (max-width: 480px) {
-        .post-title {
-            font-size: 1rem;
-        }
-
-        .post-meta {
-            font-size: 0.7rem;
-        }
-
-        .post-image {
-            width: 100px;
-            height: 100px;
-        }
     }
 </style>

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -65,8 +65,8 @@
     .post-title-link {
         text-decoration: none;
         color: inherit;
-        display: block; /* Zorg ervoor dat de link de volledige kaart beslaat */
-        width: 100%; /* Zorg ervoor dat de link altijd de volledige breedte van de kaart heeft */
+        display: block;
+        width: 100%;
     }
 
     .post-title-link:hover {
@@ -91,8 +91,8 @@
     }
 
     .post-card:hover {
-        transform: translateY(-5px); /* Vergroten bij hover */
-        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); /* Diepere schaduw bij hover */
+        transform: translateY(-5px); 
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); 
     }
 
     .post-image {

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script>
     import Footer from '$lib/Organism/Footer.svelte';
     import Header from '$lib/Organism/Header.svelte';
+    import Nav from '$lib/Organism/Nav.svelte';
 
     export let data;
 
@@ -10,7 +11,8 @@
     };
 </script>
 
-<Header alwaysSticky={false}/>
+<Header alwaysSticky={true}/>
+<Nav alwaysSticky={true}/>
 <div class="background">
 <main class="posts-container">
     {#if data.posts}

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -14,35 +14,35 @@
 <Header alwaysSticky={true}/>
 <Nav alwaysSticky={true}/>
 <div class="background">
-<main class="posts-container">
-    {#if data.posts}
-        {#each data.posts as post}
-            <article class="post-card">
+    <main class="posts-container">
+        {#if data.posts}
+            {#each data.posts as post}
                 <a href="/{post.slug}" class="post-title-link">
-                    <h3 class="post-title">{@html post.title.rendered}</h3>
+                    <article class="post-card">
+                        <h3 class="post-title">{@html post.title.rendered}</h3>
+                        <img 
+                            src={post.yoast_head_json.og_image[0].url} 
+                            alt="Artikel afbeelding" 
+                            class="post-image" 
+                            width="350" 
+                            height="350" 
+                        />
+                        <div class="post-meta">
+                            <p class="post-date">
+                                {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
+                            </p>
+                            <p class="post-read-time">
+                                {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
+                            </p>
+                            <p class="post-author">{post.yoast_head_json.author}</p>
+                        </div>
+                    </article>
                 </a>
-                <img 
-                    src={post.yoast_head_json.og_image[0].url} 
-                    alt="Artikel afbeelding" 
-                    class="post-image" 
-                    width="350" 
-                    height="350" 
-                />
-                <div class="post-meta">
-                    <p class="post-date">
-                        {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
-                    </p>
-                    <p class="post-read-time">
-                        {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
-                    </p>
-                    <p class="post-author">{post.yoast_head_json.author}</p>
-                </div>
-            </article>
-        {/each}
-    {:else}
-        <p class="no-posts-message">No posts available</p>
-    {/if}
-</main>
+            {/each}
+        {:else}
+            <p class="no-posts-message">No posts available</p>
+        {/if}
+    </main>
 </div>
 
 <Footer />
@@ -62,6 +62,17 @@
         background-color: var(--paper-color);
     }
 
+    .post-title-link {
+        text-decoration: none;
+        color: inherit;
+        display: block; /* Zorg ervoor dat de link de volledige kaart beslaat */
+        width: 100%; /* Zorg ervoor dat de link altijd de volledige breedte van de kaart heeft */
+    }
+
+    .post-title-link:hover {
+        text-decoration: underline;
+    }
+
     .post-card {
         display: flex;
         justify-content: space-between;
@@ -70,11 +81,18 @@
         max-width: 800px;
         margin: 0 auto;
         padding: 1rem;
+        cursor: pointer;
         background: #fff;
         border: 1px solid #ddd;
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
         box-sizing: border-box;
         position: relative;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+    }
+
+    .post-card:hover {
+        transform: translateY(-5px); /* Vergroten bij hover */
+        box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2); /* Diepere schaduw bij hover */
     }
 
     .post-image {
@@ -90,15 +108,6 @@
         margin: 0;
         flex-grow: 1;
         padding-right: 1rem;
-    }
-
-    .post-title-link {
-        text-decoration: none;
-        color: inherit;
-    }
-
-    .post-title-link:hover {
-        text-decoration: underline;
     }
 
     .post-meta {
@@ -117,6 +126,7 @@
     @media (max-width: 768px) {
         .post-card {
             max-width: 600px;
+            width: 100%;
         }
 
         .post-image {

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -1,10 +1,11 @@
 <script>
     import Footer from '$lib/Organism/Footer.svelte';
     import Header from '$lib/Organism/Header.svelte';
-    import Nav from '$lib/Organism/Nav.svelte';
+
     
     export let data;
-    export let categoryName;
+
+
 
     const dateFormat = {
         month: 'short',
@@ -15,7 +16,6 @@
 <Header alwaysSticky={false}/>
 <div class="background">
 <main class="posts-container">
-    <h1 class="page-title">Je bekijkt berichten in de categorie: {categoryName}</h1>
     {#if data.posts}
         {#each data.posts as post}
             <article class="post-card">
@@ -68,9 +68,6 @@
         background-color: var(--paper-color);
     }
 
-    h1{
-        margin-top: -2rem;
-    }
     
     /* Individuele post-kaart */
     .post-card {
@@ -123,6 +120,10 @@
         left: 1rem; /* Plaatst het naar links in de hoek */
         display: flex;
         gap: 0.2rem;
+    }
+
+    .post-author {
+        font-weight: var(--font-style-bold); /* Vetgedrukte auteur */
     }
     
     @media (max-width: 768px) {

--- a/src/routes/categorie/[slug]/+page.svelte
+++ b/src/routes/categorie/[slug]/+page.svelte
@@ -2,10 +2,7 @@
     import Footer from '$lib/Organism/Footer.svelte';
     import Header from '$lib/Organism/Header.svelte';
 
-    
     export let data;
-
-
 
     const dateFormat = {
         month: 'short',
@@ -30,14 +27,14 @@
                     height="350" 
                 />
                 <div class="post-meta">
-                <p class="post-date">
-                    {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
-                </p>
-                <p class="post-read-time">
-                    {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
-                </p>
-                <p class="post-author">{post.yoast_head_json.author}</p>
-            </div>
+                    <p class="post-date">
+                        {(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}
+                    </p>
+                    <p class="post-read-time">
+                        {post.yoast_head_json.twitter_misc["Geschatte leestijd"]}
+                    </p>
+                    <p class="post-author">{post.yoast_head_json.author}</p>
+                </div>
             </article>
         {/each}
     {:else}
@@ -46,110 +43,98 @@
 </main>
 </div>
 
-
 <Footer />
 
-
-
 <style>
-
-/* Container voor posts */
     .posts-container {
         display: flex;
-        flex-direction: column; /* Artikelen onder elkaar */
-        gap: 1rem; /* Ruimte tussen de artikelen */
-        padding: 3em 1.5em; /* Ruimte aan de zijkanten */
-        align-items: center; /* Zorgt ervoor dat de posts in het midden staan */
-        justify-content: center; /* Geeft meer ruimte rondom */
-        box-sizing: border-box; /* Zorgt ervoor dat padding binnen de breedte valt */
+        flex-direction: column;
+        gap: 1rem;
+        padding: 3em 1.5em;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
     }
 
-    .background{
+    .background {
         background-color: var(--paper-color);
     }
 
-    
-    /* Individuele post-kaart */
     .post-card {
         display: flex;
-        justify-content: space-between; /* Zorgt ervoor dat de afbeelding altijd rechts komt */
-        align-items: flex-start; /* Zorgt ervoor dat de titel bovenaan staat */
+        justify-content: space-between;
+        align-items: flex-start;
         width: 100%;
-        max-width: 800px; /* Max breedte van het artikel */
+        max-width: 800px;
         margin: 0 auto;
-        padding: 1rem; /* Kleinere padding */
+        padding: 1rem;
         background: #fff;
         border: 1px solid #ddd;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        box-sizing: border-box; /* Zorgt ervoor dat padding binnen de breedte valt */
-        position: relative; /* Voor positionering van de info onderaan */
+        box-sizing: border-box;
+        position: relative;
     }
-    
-    /* Afbeelding in de post - rechtse afbeelding */
+
     .post-image {
         object-fit: cover;
-        width: 200px; /* Zorgt voor een breedte van de afbeelding */
+        width: 200px;
         height: auto;
         border: 1px solid black;
-        flex-shrink: 0; /* Zorgt ervoor dat de afbeelding niet krimpt */
+        flex-shrink: 0;
     }
-    
-    /* Post-inhoud */
+
     .post-title {
         font-size: 1.2rem;
-        margin: 0; /* Geen marge boven of onder de titel */
-        flex-grow: 1; /* Zorgt ervoor dat de titel ruimte krijgt */
-        padding-right: 1rem; /* Ruimte tussen de titel en de afbeelding */
+        margin: 0;
+        flex-grow: 1;
+        padding-right: 1rem;
     }
-    
-    /* Titel-link */
+
     .post-title-link {
         text-decoration: none;
         color: inherit;
     }
-    
+
     .post-title-link:hover {
         text-decoration: underline;
     }
-    
-    /* Datum, leestijd, en auteur in de hoek onderaan */
+
     .post-meta {
-        font-size: 0.8rem; /* Kleinere tekst voor de metadata */
+        font-size: 0.8rem;
         position: absolute;
-        bottom: 0.5rem; /* Een beetje afstand van de onderkant */
-        left: 1rem; /* Plaatst het naar links in de hoek */
+        bottom: 0.5rem;
+        left: 1rem;
         display: flex;
         gap: 0.2rem;
     }
 
     .post-author {
-        font-weight: var(--font-style-bold); /* Vetgedrukte auteur */
+        font-weight: var(--font-style-bold);
     }
-    
+
     @media (max-width: 768px) {
         .post-card {
-            max-width: 600px; /* Kleinere max breedte voor tablets en kleiner */
+            max-width: 600px;
         }
-    
+
         .post-image {
-            width: 120px; /* Kleinere afbeelding voor tablets */
-            height: 120px; /* Zorgt dat de afbeelding proportioneel is */
+            width: 120px;
+            height: 120px;
         }
     }
-    
+
     @media (max-width: 480px) {
         .post-title {
-            font-size: 1rem; /* Kleinere titel op mobiele apparaten */
+            font-size: 1rem;
         }
-    
+
         .post-meta {
-            font-size: 0.7rem; /* Nog kleinere tekst voor mobiel */
+            font-size: 0.7rem;
         }
-    
+
         .post-image {
-            width: 100px; /* Kleinere afbeelding voor mobiele apparaten */
-            height: 100px; /* Zorgt dat de afbeelding proportioneel is */
+            width: 100px;
+            height: 100px;
         }
     }
-    
 </style>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -2,13 +2,9 @@
     import Footer from '$lib/Organism/Footer.svelte';
     import Header from '$lib/Organism/Header.svelte';
     import SearchBar from '$lib/Molecules/SearchBar.svelte';
+    import ArticleAlt from '$lib/Molecules/ArticleAlt.svelte';
 
     export let data;
-
-    const dateFormat = {
-        month: 'short',
-        day: 'numeric',
-    };
 </script>
 
 <Header/>
@@ -23,17 +19,11 @@
     </div>
     {#if data.posts.length > 0}
         <h1>Zoekresultaten voor &quot;{data.searchterm}&quot; :</h1>
-        {#each data.posts as post}
-        <!-- @html means: there is html in this string, render it -->
-            <a href="/{post.slug}">
-                <h3>{@html post.title.rendered}</h3>
-            </a>
-            <p>{@html post.excerpt.rendered}</p>
-            <img src={post.yoast_head_json.og_image[0].url} alt="Artikel afbeelding">
-            <p>{(new Date(post.date)).toLocaleDateString("nl-NL", dateFormat)}</p>
-            <p>{post.yoast_head_json.twitter_misc["Geschatte leestijd"]}</p>
-            <p>{post.yoast_head_json.author}</p>
-        {/each}
+        <div class="posts-container">
+            {#each data.posts as post}
+                <ArticleAlt post={post} />
+            {/each}
+        </div>
     {:else}
         <!-- This will show if no posts are available -->
         <h1>Geen resultaten gevonden voor: &quot;{data.searchterm}&quot;</h1>
@@ -43,14 +33,9 @@
 <Footer/>
 
 <style>
-
     h1 {
         text-align: center;
         margin: 2em;
-    }
-
-    a {
-        color: var(--background-color);
     }
 
     .search-main {
@@ -60,8 +45,12 @@
         margin-right: auto;
     }
 
-    img {
-        max-width: 100%;
-        height: auto;
+    .posts-container {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
     }
 </style>


### PR DESCRIPTION
## What does this change?

Resolves issue #62 

Ik heb de styling aangepast naar de **Red Pers styling** voor de categorieën. Meerdere artikelen zijn nu duidelijk zichtbaar en worden netjes en responsief weergegeven. 

[livesite](https://news-categories.netlify.app/categorie/buitenland)

## Het ziet er nu zo uit: 

![Screenshot 2025-01-16 140415](https://github.com/user-attachments/assets/7eadb578-a443-4ecb-9ef2-467a525402fc)

## How Has This Been Tested?

- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [x] Browser test

## Accessibility / Performance
![Screenshot 2025-01-16 132658](https://github.com/user-attachments/assets/c986ad1d-7e11-4e22-a0fb-2137f21038f3)

## Tab test
https://github.com/user-attachments/assets/87309026-0f98-405a-a0a5-6832aeaa975c

## Responsive
https://github.com/user-attachments/assets/cdfb27ac-530e-4367-9448-b72d99a8ac59

## Firefox
![Screenshot 2025-01-16 141252](https://github.com/user-attachments/assets/18029e40-1b4a-48d1-b591-cf22476c9326)


## How to review

Open de [livesite](https://news-categories.netlify.app/categorie/buitenland) en bekijk de wijzigingen in de styling en test op basis van de bovengenoemde punten. Het is mij niet gelukt om dynamisch de categorie op te halen en die bijvoorbeeld in een h1 te zetten, kunnen we daar even samen naar kijken? 
